### PR TITLE
Remove unnecessary apt-get update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN apt-get update && \
     apt-get -y install xz-utils && \
     cd ~ && \
     wget https://developer.salesforce.com/media/salesforce-cli/sfdx-v5.6.22-f9533ba-linux-amd64.tar.xz -O sfdx.tar.xz && \
-    apt-get update && \
     tar -xvJf ~/sfdx.tar.xz && \
     cd heroku && \
     ./install && \


### PR DESCRIPTION
It also splits the download of sfdx from its extraction, which makes the file difficult to follow.